### PR TITLE
Fix error related to array items not having a validation type

### DIFF
--- a/lib/endpoints/class-wp-rest-multiple-posttype-controller.php
+++ b/lib/endpoints/class-wp-rest-multiple-posttype-controller.php
@@ -344,6 +344,9 @@ class WP_REST_Multiple_PostType_Controller extends WP_REST_Controller {
             'default' => array(),
             'sanitize_callback' => 'wp_parse_id_list',
             'validate_callback' => 'rest_validate_request_arg',
+            'items' => array (
+                'type' => 'integer',
+            ),
         );
         $params['author_exclude'] = array(
             'description' => __('Ensure result set excludes posts assigned to specific authors.'),
@@ -351,6 +354,9 @@ class WP_REST_Multiple_PostType_Controller extends WP_REST_Controller {
             'default' => array(),
             'sanitize_callback' => 'wp_parse_id_list',
             'validate_callback' => 'rest_validate_request_arg',
+            'items' => array (
+                'type' => 'integer',
+            ),
         );
 
         $params['before'] = array(

--- a/lib/endpoints/class-wp-rest-multiple-posttype-controller.php
+++ b/lib/endpoints/class-wp-rest-multiple-posttype-controller.php
@@ -344,7 +344,7 @@ class WP_REST_Multiple_PostType_Controller extends WP_REST_Controller {
             'default' => array(),
             'sanitize_callback' => 'wp_parse_id_list',
             'validate_callback' => 'rest_validate_request_arg',
-            'items' => array (
+            'items' => array(
                 'type' => 'integer',
             ),
         );
@@ -354,7 +354,7 @@ class WP_REST_Multiple_PostType_Controller extends WP_REST_Controller {
             'default' => array(),
             'sanitize_callback' => 'wp_parse_id_list',
             'validate_callback' => 'rest_validate_request_arg',
-            'items' => array (
+            'items' => array(
                 'type' => 'integer',
             ),
         );


### PR DESCRIPTION
rest_validate_value_from_schema() attempts to recursively validate array items (if `type` is set to `array`) using an `items` arg. This was not set for either of the author-related query params (`author` and `author_exclude`).