### PR TITLE
Fix activation fatal error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -13,12 +13,11 @@
 /**
  * WP_REST_Multiple_PostType_Controller class.
  */
-if (!class_exists('WP_REST_Multiple_PostType_Controller')) {
-
-    require_once dirname(__FILE__) . '/lib/endpoints/class-wp-rest-multiple-posttype-controller.php';
-}
 
 function init_wp_rest_multiple_posttype_endpoint() {
+    if (!class_exists('WP_REST_Multiple_PostType_Controller')) {
+        require_once dirname(__FILE__) . '/lib/endpoints/class-wp-rest-multiple-posttype-controller.php';
+    }
     $controller = new WP_REST_Multiple_PostType_Controller();
     $controller->register_routes();
 }


### PR DESCRIPTION
Moving the require_once inside the init function fixes the "Fatal error: Class 'WP_REST_Controller' not found" on activation.